### PR TITLE
mimic Buffer implementation

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,16 +1,24 @@
+module.exports = function(a, b) {
+  if (a === b) return 0
 
+  var x = a.length
+  var y = b.length
 
-module.exports = function(cmp,to){
-  var c = 0;
-  for(var i=0;i<cmp.length;++i){
-    if(i == to.length) break;
-    c = cmp[i] < to[i]?-1:cmp[i] > to[i]?1:0;    
-    if(c != 0) break;
+  var i = 0
+  var len = Math.min(x, y)
+  while (i < len) {
+    if (a[i] !== b[i]) break
+
+    ++i
   }
-  if(c == 0){
-    if(to.length > cmp.length) c = -1;
-    else if(cmp.length > to.length) c = 1;
+
+  if (i !== len) {
+    x = a[i]
+    y = b[i]
   }
-  return c;
+
+  if (x < y) return -1
+  if (y < x) return 1
+  return 0
 }
 


### PR DESCRIPTION
This PR mimics the `compare` code in [feross/buffer](https://github.com/feross/buffer/blob/master/index.js#L264-L290), which is used node browserify.
This would allow you to seamlessly use `buffer-compare` in any environment, and combined with https://github.com/soldair/node-buffer-compare/pull/2 should mean I can guarantee it will work in old versions of node, and new, and the browser.
